### PR TITLE
Refactor host port assignment logic in generator.py

### DIFF
--- a/utils/generator.py
+++ b/utils/generator.py
@@ -48,9 +48,7 @@ def substitute_port_placeholders(
         if match:
             container_port = match.group(2)
             # Use indexed port if available, otherwise fallback to first port
-            host_port = (
-                actual_ports[idx] if idx < len(actual_ports) else actual_ports[0]
-            )
+            host_port = actual_ports[idx % len(actual_ports)] if isinstance(actual_ports, list) else actual_ports
             new_ports.append(f"{host_port}:{container_port}")
         else:
             # If not a placeholder, keep as is


### PR DESCRIPTION
Do you want to enable (multi)proxy? (y/n) (default: no): Assembling Docker Compose file... \
[WARNING] Cannot check architecture/tag for GHCR image ghcr.io/techroy23/docker-wipter. (As it would require a GH PAT). Using provided tag 'latest'. Done
Traceback (most recent call last):
  File "/home/dvsrk/money4band/main.py", line 268, in <module>
    main()
  File "/home/dvsrk/money4band/main.py", line 256, in main
    mainmenu(
  File "/home/dvsrk/money4band/main.py", line 146, in mainmenu
    m4b_tools_modules[function_name].main(
  File "/home/dvsrk/money4band/utils/fn_setupApps.py", line 1005, in main
    assemble_docker_compose(
  File "/home/dvsrk/money4band/utils/generator.py", line 152, in assemble_docker_compose
    app_compose_config["ports"] = substitute_port_placeholders(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dvsrk/money4band/utils/generator.py", line 52, in substitute_port_placeholders
    actual_ports[idx] if idx < len(actual_ports) else actual_ports[0]
                               ^^^^^^^^^^^^^^^^^
TypeError: object of type 'int' has no len()